### PR TITLE
Changed the implementation of `Display::fmt`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,15 @@ pub mod matrix_algebra {
             let rows = self.rows();
             for (i, row) in rows.clone().into_iter().enumerate() {
                 let printable_row: String =
-                    row.iter().map(|&entry| entry.to_string() + " ").collect();
+                    row.iter().map(|&entry| {
+                    	let mut entry_as_string = entry.to_string();
+                    	
+                    	while entry_as_string.len() < 4 {
+                    		entry_as_string += " ";
+                    	}
+
+                    	entry_as_string + " "
+                    }).collect();
                 if i == 0 {
                     let _ = fmt.write_str("⌜");
                 } else if i == &rows.len() - 1 {


### PR DESCRIPTION
* Matrix entries are padded out to 4 characters long to preserve alignment
* This will obviously not work for numbers longer than 4 digits but is sufficient for the time being