### PR TITLE
Row echolon form cleanup

### DIFF
--- a/src/matrix_algebra.rs
+++ b/src/matrix_algebra.rs
@@ -181,7 +181,7 @@ impl<T: MatrixElementRequiredTraits<T>> Matrix<T> {
         true
     }
 
-    pub fn row_echolon_form(&self, k: usize) -> Matrix<T> {
+    fn row_echolon_form_recursive(&self, k: usize) -> Matrix<T> {
         let mut partitioned: Vec<Matrix<T>> = Vec::new();
 
         if k != 0 {
@@ -239,14 +239,18 @@ impl<T: MatrixElementRequiredTraits<T>> Matrix<T> {
         }
 
         if k != self.m - 1 {
-            return combined.row_echolon_form(k + 1);
+            return combined.row_echolon_form_recursive(k + 1);
         }
 
         combined
     }
 
+    pub fn row_echolon_form(&self) -> Matrix<T> {
+        self.row_echolon_form_recursive(0)
+    }
+
     pub fn column_echolon_form(&self) -> Matrix<T> {
-        self.transpose().row_echolon_form(0).transpose()
+        self.transpose().row_echolon_form().transpose()
     }
 
     pub fn columns(&self) -> Vec<Vec<T>> {
@@ -962,7 +966,7 @@ mod tests {
             .to_vec(),
         );
 
-        let result = test_matrix.row_echolon_form(0);
+        let result = test_matrix.row_echolon_form();
 
         assert_eq!(
             result,
@@ -993,7 +997,7 @@ mod tests {
             [4.0, -8.0, 16.0, 1.0, -3.0, 6.0, 2.0, 1.0, 1.0].to_vec(),
         );
 
-        let result = test_matrix.row_echolon_form(0);
+        let result = test_matrix.row_echolon_form();
 
         assert_eq!(result, new_identity_matrix(3));
 
@@ -1003,7 +1007,7 @@ mod tests {
             [0.0, 2.0, 1.0, 4.0, 0.0, 0.0, 2.0, 6.0, 1.0, 0.0, -3.0, 2.0].to_vec(),
         );
 
-        let result = test_matrix.row_echolon_form(0);
+        let result = test_matrix.row_echolon_form();
 
         assert_eq!(
             result,
@@ -1031,7 +1035,7 @@ mod tests {
             .to_vec(),
         );
 
-        let result = test_matrix.row_echolon_form(0);
+        let result = test_matrix.row_echolon_form();
 
         assert_eq!(
             result,
@@ -1067,7 +1071,7 @@ mod tests {
             .to_vec(),
         );
 
-        let result = test_matrix.row_echolon_form(0);
+        let result = test_matrix.row_echolon_form();
 
         assert_eq!(
             result,

--- a/src/matrix_algebra.rs
+++ b/src/matrix_algebra.rs
@@ -190,8 +190,6 @@ impl<T: MatrixElementRequiredTraits<T>> Matrix<T> {
 
         let a_k = if k == 0 { self } else { &partitioned[1] };
 
-        println!("j) a_k:\n{}", a_k);
-
         if a_k.all_zeroes() {
             return self.clone();
         }
@@ -199,10 +197,6 @@ impl<T: MatrixElementRequiredTraits<T>> Matrix<T> {
         let rows = a_k.rows();
         let columns = a_k.columns();
         let first_non_zero_column_index = first_non_zero_vec_index(&columns);
-        println!(
-            "d) first non-zero column of a_k: {}",
-            first_non_zero_column_index
-        );
         let mut first_row_with_non_zero_entry = 0;
 
         for row in &rows {
@@ -212,25 +206,12 @@ impl<T: MatrixElementRequiredTraits<T>> Matrix<T> {
             first_row_with_non_zero_entry += 1;
         }
 
-        println!(
-            "e) first row having non-zero entry in column {}: {}",
-            first_non_zero_column_index, first_row_with_non_zero_entry
-        );
-
-        println!(
-            "f) interchanging row {} with {}",
-            0, first_row_with_non_zero_entry
-        );
         let a_k_interchanged = a_k.row_interchange(0, first_row_with_non_zero_entry);
         println!("f) {}", a_k_interchanged);
         let rows = a_k_interchanged.rows();
         let leading_entry_of_first_row = &rows[0][first_non_zero_column_index];
         let scalar = T::from(1) / *leading_entry_of_first_row;
         let mut a_k = a_k_interchanged.multiply_row_by_scalar(0, scalar);
-        println!(
-            "g) making first row equal to 1 by multiplying by {}:\n{}",
-            scalar, a_k
-        );
 
         let combined_entries = if k == 0 {
             &a_k.entries
@@ -257,12 +238,6 @@ impl<T: MatrixElementRequiredTraits<T>> Matrix<T> {
             }
         }
 
-        println!(
-            "h) reduce all other entries of column {} of A to 0:\n{}",
-            first_non_zero_column_index, combined
-        );
-
-        println!("i) Does k == m? k: {}, m: {}", k, self.m - 1);
         if k != self.m - 1 {
             return combined.row_echolon_form(k + 1);
         }


### PR DESCRIPTION
* Removed all the caveman debugging used to test row_echolon_form and its intermediate steps
* Changed the public API of row_echolon_form so that it is no longer parameterised in k (this is an internal implementation detail)